### PR TITLE
Improve AddCommandTest

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -47,7 +47,7 @@ public class AddCommand extends Command {
             + PREFIX_EMAIL + "johnd@example.com "
             + PREFIX_ADDRESS + "311, Clementi Ave 2, #02-25 "
             + PREFIX_TAG + "friends "
-            + PREFIX_TAG + "owesMoney"
+            + PREFIX_TAG + "owesMoney "
             + PREFIX_ASSET + "screwdriver";
 
     public static final String MESSAGE_SUCCESS = "New person added: %1$s";

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -38,6 +38,7 @@ import static seedu.address.model.person.fields.Address.PREFIX_ADDRESS;
 import static seedu.address.model.person.fields.Email.PREFIX_EMAIL;
 import static seedu.address.model.person.fields.Name.PREFIX_NAME;
 import static seedu.address.model.person.fields.Phone.PREFIX_PHONE;
+import static seedu.address.model.person.fields.Tags.PREFIX_TAG;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.AMY;
@@ -196,6 +197,33 @@ public class AddCommandTest {
         // invalid address
         assertParseFailure(AddCommand::of, validExpectedPersonString + INVALID_ADDRESS_DESC,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_ADDRESS));
+    }
+
+    @Test
+    public void of_emptyValue_failure() {
+        // Empty name
+        assertParseFailure(AddCommand::of, " " + PREFIX_NAME + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
+                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND + ASSET_DESC_AIRCON + ASSET_DESC_HAMMER);
+
+        // Empty phone
+        assertParseFailure(AddCommand::of, NAME_DESC_BOB + " " + PREFIX_PHONE + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
+                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND + ASSET_DESC_AIRCON + ASSET_DESC_HAMMER);
+
+        // Empty Email
+        assertParseFailure(AddCommand::of, NAME_DESC_BOB + PHONE_DESC_BOB + " " + PREFIX_EMAIL + ADDRESS_DESC_BOB
+                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND + ASSET_DESC_AIRCON + ASSET_DESC_HAMMER);
+
+        // Empty Tag
+        assertParseFailure(AddCommand::of, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
+                + TAG_DESC_HUSBAND + " " + PREFIX_TAG + ASSET_DESC_HAMMER);
+
+    }
+
+    @Test
+    public void of_parametersInDifferentOrder_success() {
+        Person expectedPerson = new PersonBuilder(AMY).withTags().withAssets().build();
+        assertParseSuccess(AddCommand::of, EMAIL_DESC_AMY + PHONE_DESC_AMY + NAME_DESC_AMY + ADDRESS_DESC_AMY,
+                new AddCommand(expectedPerson));
     }
 
     @Test


### PR DESCRIPTION
Enhance AddCommandTest coverage by adding scenarios for empty string parameters and order-independent parameter tests, ensuring robust error handling and accurate processing of user inputs in varying formats.

Fix whitespace in Add command error message

Missing whitespace in error message fixed.
Closes #94 and #98 