### PR TITLE
Update Asset fields and change method of editing

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AssetCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AssetCommand.java
@@ -16,9 +16,9 @@ import seedu.address.model.person.fields.Prefix;
 /**
  * Edits the details of an asset in the address book.
  */
-public class EditAssetCommand extends Command {
+public class AssetCommand extends Command {
 
-    public static final String COMMAND_WORD = "edita";
+    public static final String COMMAND_WORD = "asset";
     public static final Prefix PREFIX_OLD = new Prefix("old/");
     public static final Prefix PREFIX_NEW = new Prefix("new/");
 
@@ -39,7 +39,7 @@ public class EditAssetCommand extends Command {
      * @param target Previous asset to replace.
      * @param editedAsset New asset to replace with.
      */
-    public EditAssetCommand(Asset target, Asset editedAsset) {
+    public AssetCommand(Asset target, Asset editedAsset) {
         requireNonNull(target);
         requireNonNull(editedAsset);
 
@@ -68,7 +68,7 @@ public class EditAssetCommand extends Command {
      * and returns an EditCommand object for execution.
      * @throws IllegalArgumentException if the user input does not conform the expected format
      */
-    public static EditAssetCommand of(String args) throws IllegalArgumentException {
+    public static AssetCommand of(String args) throws IllegalArgumentException {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_OLD, PREFIX_NEW);
@@ -76,14 +76,14 @@ public class EditAssetCommand extends Command {
         if (!arePrefixesPresent(argMultimap, PREFIX_OLD, PREFIX_NEW)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new IllegalArgumentException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    EditAssetCommand.MESSAGE_USAGE));
+                    AssetCommand.MESSAGE_USAGE));
         }
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_OLD, PREFIX_NEW);
         Asset target = Asset.of(argMultimap.getValue(PREFIX_OLD).get());
         Asset editedAsset = Asset.of(argMultimap.getValue(PREFIX_NEW).get());
 
-        return new EditAssetCommand(target, editedAsset);
+        return new AssetCommand(target, editedAsset);
     }
 
     /**
@@ -101,11 +101,11 @@ public class EditAssetCommand extends Command {
         }
 
         // instanceof handles nulls
-        if (!(other instanceof EditAssetCommand)) {
+        if (!(other instanceof AssetCommand)) {
             return false;
         }
 
-        EditAssetCommand otherEditCommand = (EditAssetCommand) other;
+        AssetCommand otherEditCommand = (AssetCommand) other;
         return target.equals(otherEditCommand.target)
                 && editedAsset.equals(otherEditCommand.editedAsset);
     }

--- a/src/main/java/seedu/address/logic/commands/CommandType.java
+++ b/src/main/java/seedu/address/logic/commands/CommandType.java
@@ -20,7 +20,7 @@ public enum CommandType {
     EDITA {
         @Override
         public Command createCommand(String arguments) throws IllegalArgumentException {
-            return EditAssetCommand.of(arguments);
+            return AssetCommand.of(arguments);
         }
     },
     DELETE {

--- a/src/main/java/seedu/address/logic/commands/CommandType.java
+++ b/src/main/java/seedu/address/logic/commands/CommandType.java
@@ -17,7 +17,7 @@ public enum CommandType {
             return EditCommand.of(arguments);
         }
     },
-    EDITA {
+    ASSET {
         @Override
         public Command createCommand(String arguments) throws IllegalArgumentException {
             return AssetCommand.of(arguments);

--- a/src/main/java/seedu/address/model/asset/Asset.java
+++ b/src/main/java/seedu/address/model/asset/Asset.java
@@ -2,6 +2,7 @@ package seedu.address.model.asset;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
@@ -19,12 +20,10 @@ public class Asset {
     private final String assetLocation;
 
     private Asset(String assetName, String assetId, String assetLocation) {
-        requireNonNull(assetName);
-        requireNonNull(assetId);
-        requireNonNull(assetLocation);
-        this.assetName = assetName.trim();
-        this.assetId = assetId.trim();
-        this.assetLocation = assetLocation.trim();
+        requireAllNonNull(assetName, assetId, assetLocation);
+        this.assetName = assetName;
+        this.assetId = assetId;
+        this.assetLocation = assetLocation;
     }
 
     @JsonValue
@@ -40,8 +39,7 @@ public class Asset {
     }
 
     /**
-     * Parses a {@code String} of format {@code <name>#<id>@<location>} into a {@code Asset}.
-     * {@code <id>} and {@code <location>} are optional.
+     * Parses a {@code String} of format {@code NAME[#ID][@LOCATION]} into a {@code Asset}.
      * Leading and trailing whitespaces of each field will be trimmed.
      *
      * @throws IllegalArgumentException if the given {@code name} is invalid.
@@ -56,13 +54,13 @@ public class Asset {
         String trimmedDescription = assetDescription.trim();
         String[] splitByAt = trimmedDescription.split("@", 2);
         if (splitByAt.length == 2) {
-            location = splitByAt[1];
+            location = splitByAt[1].trim();
         }
         String[] splitByHash = splitByAt[0].split("#", 2);
         if (splitByHash.length == 2) {
-            id = splitByHash[1];
+            id = splitByHash[1].trim();
         }
-        String name = splitByHash[0];
+        String name = splitByHash[0].trim();
 
         return new Asset(name, id, location);
     }

--- a/src/main/java/seedu/address/model/person/fields/Assets.java
+++ b/src/main/java/seedu/address/model/person/fields/Assets.java
@@ -35,7 +35,7 @@ public class Assets implements Field {
      */
     public Assets(String... assetNames) {
         this.assets = Stream.of(assetNames)
-                            .map(Asset::new)
+                            .map(Asset::of)
                             .collect(Collectors.toUnmodifiableSet());
     }
 

--- a/src/test/java/seedu/address/logic/commands/AssetCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AssetCommandTest.java
@@ -5,9 +5,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.assertParseFailure;
-import static seedu.address.logic.commands.EditAssetCommand.MESSAGE_INVALID_ASSET_NAME;
-import static seedu.address.logic.commands.EditAssetCommand.MESSAGE_NOT_EDITED;
-import static seedu.address.logic.commands.EditAssetCommand.MESSAGE_SUCCESS;
+import static seedu.address.logic.commands.AssetCommand.MESSAGE_INVALID_ASSET_NAME;
+import static seedu.address.logic.commands.AssetCommand.MESSAGE_NOT_EDITED;
+import static seedu.address.logic.commands.AssetCommand.MESSAGE_SUCCESS;
 import static seedu.address.model.asset.Asset.MESSAGE_CONSTRAINTS;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
@@ -26,10 +26,10 @@ import seedu.address.testutil.PersonBuilder;
 /**
  * Contains integration tests (interaction with the Model) and unit tests for EditCommand.
  */
-public class EditAssetCommandTest {
+public class AssetCommandTest {
 
     private static final String MESSAGE_INVALID_FORMAT =
-            String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditAssetCommand.MESSAGE_USAGE);
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, AssetCommand.MESSAGE_USAGE);
     private static final String MESSAGE_CONSTRAINT_NAME = "Names should only contain alphanumeric characters and "
             + "spaces, and it should not be blank";
     private final Asset asset1 = Asset.of("laptop");
@@ -42,7 +42,7 @@ public class EditAssetCommandTest {
         Person personWithAsset = new PersonBuilder().withAssets(asset1.get()).build();
         model.addPerson(personWithAsset);
         Asset editedAsset = new AssetBuilder().build();
-        EditAssetCommand editCommand = new EditAssetCommand(asset1, editedAsset);
+        AssetCommand editCommand = new AssetCommand(asset1, editedAsset);
 
         String expectedMessage = String.format(MESSAGE_SUCCESS, editedAsset);
 
@@ -53,7 +53,7 @@ public class EditAssetCommandTest {
     @Test
     public void execute_notEdited_throwsCommandException() {
         assertThrows(CommandException.class, MESSAGE_NOT_EDITED, () ->
-                new EditAssetCommand(asset1, asset1).execute(model));
+                new AssetCommand(asset1, asset1).execute(model));
     }
 
     @Test
@@ -61,7 +61,7 @@ public class EditAssetCommandTest {
         Person personWithAsset = new PersonBuilder().withAssets(asset1.get()).build();
         model.addPerson(personWithAsset);
         Asset invalidEditedAsset = new AssetBuilder().build();
-        EditAssetCommand editCommand = new EditAssetCommand(invalidEditedAsset, asset1);
+        AssetCommand editCommand = new AssetCommand(invalidEditedAsset, asset1);
 
         assertThrows(CommandException.class, MESSAGE_INVALID_ASSET_NAME, () ->
                 editCommand.execute(model));
@@ -70,45 +70,45 @@ public class EditAssetCommandTest {
     @Test
     public void execute_emptyDescriptor_throwsCommandException() {
         assertThrows(IllegalArgumentException.class, MESSAGE_CONSTRAINTS, () ->
-                new EditAssetCommand(Asset.of(""), asset1));
+                new AssetCommand(Asset.of(""), asset1));
     }
 
     @Test
     public void of_invalidInput_failure() {
         // missing field
-        assertParseFailure(EditAssetCommand::of, "Laptop", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(AssetCommand::of, "Laptop", MESSAGE_INVALID_FORMAT);
         // missing field
-        assertParseFailure(EditAssetCommand::of, "", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(AssetCommand::of, "", MESSAGE_INVALID_FORMAT);
         // null
-        assertThrows(NullPointerException.class, () -> EditAssetCommand.of(null));
+        assertThrows(NullPointerException.class, () -> AssetCommand.of(null));
         // unedited
-        assertThrows(IllegalArgumentException.class, () -> EditAssetCommand.of("Laptop Laptop"));
+        assertThrows(IllegalArgumentException.class, () -> AssetCommand.of("Laptop Laptop"));
         // only alphanum allowed for name
-        assertThrows(IllegalArgumentException.class, () -> EditAssetCommand.of("Laptop \uD83D\uDC4D"));
+        assertThrows(IllegalArgumentException.class, () -> AssetCommand.of("Laptop \uD83D\uDC4D"));
     }
 
     @Test
     public void of_validInput_success() {
-        assertDoesNotThrow(() -> EditAssetCommand.of(" old/aircon new/desktop"));
+        assertDoesNotThrow(() -> AssetCommand.of(" old/aircon new/desktop"));
     }
 
     @Test
     public void equals_sameValues_returnsTrue() {
-        EditAssetCommand editCommand1 = new EditAssetCommand(asset1, asset2);
-        EditAssetCommand editCommand2 = new EditAssetCommand(asset1, asset2);
+        AssetCommand editCommand1 = new AssetCommand(asset1, asset2);
+        AssetCommand editCommand2 = new AssetCommand(asset1, asset2);
         assertEquals(editCommand1, editCommand2);
     }
 
     @Test
     public void equals_differentValues_returnsFalse() {
-        EditAssetCommand editCommand1 = new EditAssetCommand(asset1, asset2);
-        EditAssetCommand editCommand2 = new EditAssetCommand(asset2, asset1);
+        AssetCommand editCommand1 = new AssetCommand(asset1, asset2);
+        AssetCommand editCommand2 = new AssetCommand(asset2, asset1);
         assertNotEquals(editCommand1, editCommand2);
     }
 
     @Test
     public void equals_differentObject_returnsFalse() {
-        EditAssetCommand editCommand = new EditAssetCommand(asset1, asset2);
+        AssetCommand editCommand = new AssetCommand(asset1, asset2);
         assertNotEquals(editCommand, new Object());
     }
 


### PR DESCRIPTION
## Updated asset to include a id and location field

How it works: The user inputs assets in the format `A/NAME[#ID][@LOCATION]`. In other words, id and location are optional, and must be delimited by `#` and `@`.

Snippet of test code for reference (only the first 4 are valid asset descriptions)
![image](https://github.com/AY2324S2-CS2103T-W12-3/tp/assets/107540644/c89ce5a8-fb41-4fce-b74a-1c4b8e3d7b4c)

GUI display is still rudimentary
![image](https://github.com/AY2324S2-CS2103T-W12-3/tp/assets/107540644/abad1ce5-14dc-4e94-ad3b-bd2deca529db)

## Updated edita to asset
As discussed, `edita` has been renamed to `asset` in order to maintain a set of commands in "natural language".

## Tests
**In progress...**